### PR TITLE
Add prefix to current measurement

### DIFF
--- a/owon_multi_cli.c
+++ b/owon_multi_cli.c
@@ -244,11 +244,26 @@ char *funct_to_string (char *fixed_val_buf, int function, int scale, int measure
     }
 
   } else if (function == MODE_AC_AMPS) {
-    strcpy(funct_s, "AC A");
+    if (scale == 2) {
+      strcpy(funct_s, "AC µA");
+    } else if (scale == 3) {
+      strcpy(funct_s, "AC mA");	  
+    } else if (scale == 4) {
+      strcpy(funct_s, "AC A");
+    } else {
+      strcpy(funct_s, "??AC A");
+    }
 
   } else if (function ==MODE_DC_AMPS ) {
-    strcpy(funct_s, "DC A");
-
+    if (scale == 2) {
+      strcpy(funct_s, "DC µA");
+    } else if (scale == 3) {
+      strcpy(funct_s, "DC mA");	  
+    } else if (scale == 4) {
+      strcpy(funct_s, "DC A");
+    } else {
+      strcpy(funct_s, "??DC A");
+    }
   } else if (function == MODE_NCV) {
     strcpy(funct_s, "NCV");
 


### PR DESCRIPTION
Currently the prefix is not displayed, when measuring AC or DC current. This causes the unit to be wrong in the µA and mA range. This PR adds this. (Like it's already done for Volts)
before:
```
1703541520.41 005.8 DC A
1703541522.36 00.01 DC A
1703541527.94 0.000 DC A
```
after:
```
1703541520.41 005.8 DC µA
1703541522.36 00.01 DC mA
1703541527.94 0.000 DC A
```

Happy holidays